### PR TITLE
Using iOS getter utility for native calls

### DIFF
--- a/push-plugin.ios.js
+++ b/push-plugin.ios.js
@@ -1,3 +1,5 @@
+var utils = require("utils/utils");
+
 module.exports = (function() {
 
     var pushHandler;
@@ -21,7 +23,7 @@ module.exports = (function() {
             this.settings = settings;
             this.notificationCallbackIOS = settings.notificationCallbackIOS;
 
-            this.notificationCenter = NSNotificationCenter.defaultCenter();
+            this.notificationCenter = utils.ios.getter(NSNotificationCenter, NSNotificationCenter.defaultCenter);
 
             // subscribe to the notification received event.
             this._addObserver("notificationReceived", function(context) {
@@ -37,7 +39,7 @@ module.exports = (function() {
             var self = this;
             if (!this.didRegisterObserver) { // make sure that the events are not attached more than once
                 this.didRegisterObserver = this._addObserver("didRegisterForRemoteNotificationsWithDeviceToken", function(result) {
-                    NSNotificationCenter.defaultCenter().removeObserver(self.didRegisterObserver);
+                    self.notificationCenter.removeObserver(self.didRegisterObserver);
                     self.didRegisterObserver = undefined;
                     var token = result.userInfo.objectForKey('message');
                     success(token);
@@ -46,7 +48,7 @@ module.exports = (function() {
 
             if (!this.didFailToRegisterObserver) {
                 this.didFailToRegisterObserver = this._addObserver("didFailToRegisterForRemoteNotificationsWithError", function(e) {
-                    NSNotificationCenter.defaultCenter().removeObserver(self.didFailToRegisterObserver);
+                    self.notificationCenter.removeObserver(self.didFailToRegisterObserver);
                     self.didFailToRegisterObserver = undefined;
                     //var err = JSON.parse(e.userInfo.objectForKey('error'));
                     error(e);
@@ -73,7 +75,7 @@ module.exports = (function() {
 
                 if (!this.registerUserSettingsObserver) {
                     this.registerUserSettingsObserver = this._addObserver("didRegisterUserNotificationSettings", function() {
-                        NSNotificationCenter.defaultCenter().removeObserver(self.registerUserSettingsObserver);
+                        self.notificationCenter.removeObserver(self.registerUserSettingsObserver);
                         self.registerUserSettingsObserver = undefined;
                         success();
                     });
@@ -81,7 +83,7 @@ module.exports = (function() {
 
                 if (!this.failToRegisterUserSettingsObserver) {
                     this.failToRegisterUserSettingsObserver = this._addObserver("failToRegisterUserNotificationSettings", function(error) {
-                        NSNotificationCenter.defaultCenter().removeObserver(self.failToRegisterUserSettingsObserver);
+                        self.notificationCenter.removeObserver(self.failToRegisterUserSettingsObserver);
                         self.failToRegisterUserSettingsObserver = undefined;
                         error(error);
                     });
@@ -100,7 +102,7 @@ module.exports = (function() {
             var self = this;
             if (!this.didUnregisterObserver) {
                 this.didUnregisterObserver = this._addObserver("didUnregister", function(context) {
-                    NSNotificationCenter.defaultCenter().removeObserver(self.didUnregisterObserver);
+                    self.notificationCenter.removeObserver(self.didUnregisterObserver);
                     self.didUnregisterObserver = undefined;
                     done(context);
                 });
@@ -118,7 +120,7 @@ module.exports = (function() {
                     if(areEnabledStr === "true"){
                         areEnabled = true;
                     }
-                    NSNotificationCenter.defaultCenter().removeObserver(self.areNotificationsEnabledObserver);
+                    self.notificationCenter.removeObserver(self.areNotificationsEnabledObserver);
                     self.areNotificationsEnabledObserver = undefined;
                     done(areEnabled);
                 });
@@ -155,7 +157,12 @@ module.exports = (function() {
         },
 
         _addObserver: function(eventName, callback) {
-            return NSNotificationCenter.defaultCenter().addObserverForNameObjectQueueUsingBlock(eventName, null, NSOperationQueue.mainQueue(), callback);
+            
+            if (typeof this.notificationCenter == "undefined") {
+                this.notificationCenter = utils.ios.getter(NSNotificationCenter, NSNotificationCenter.defaultCenter)
+            }
+            
+            return this.notificationCenter.addObserverForNameObjectQueueUsingBlock(eventName, null, utils.ios.getter(NSOperationQueue, NSOperationQueue.mainQueue), callback);
         }
 
     };


### PR DESCRIPTION
For backwards compatibility on iOS 8-9, I've just replaced the native calls to use the iOS getter utility.  _addObserver seems to be called before the plugin is initiated, in which case it sets the notificationCenter property at that point if it doesn't exist.  Perhaps this is a bit redundant, but works.
